### PR TITLE
feat: Capturing current namespace and using it

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -228,11 +229,18 @@ func main() {
 		log.Fatal(err)
 	}
 
+	nsb, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		panic(err.Error())
+	}
+	namespace := string(nsb)
+
 	// the kube flags bound above include a --namespace flag...
-	namespace := "default"
 	if configOverrides.Context.Namespace != "" {
 		namespace = configOverrides.Context.Namespace
 	}
+
+	fmt.Printf("Determined namespace: %s\n", namespace)
 
 	clientset, err := kubeconfig.BuildClientset(loadingRules, configOverrides)
 	if err != nil {


### PR DESCRIPTION
As I am using a custom namespace here in the project I would always need to inform the namespace by parameter and I implemented that by default it automatically pulls the current namespace from the pod.

If that makes sense for the project I await the acceptance of my change. Thanks